### PR TITLE
Login flow fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,8 +44,7 @@ android {
         create("development") {
             setDimension("environment")
             manifestPlaceholders = mapOf<String, Any>(
-//                    "environment" to "development" // FIXME
-                    "environment" to "staging"
+                    "environment" to "development"
             )
         }
         create("staging") {
@@ -62,7 +61,7 @@ android {
         }
     }
 
-    defaultPublishConfig = "stagingDebug"
+    defaultPublishConfig = "developmentDebug"
 
 
     compileOptions {

--- a/app/src/androidTest/java/de/gesundheitscloud/sdk/integration/page/LoginPage.kt
+++ b/app/src/androidTest/java/de/gesundheitscloud/sdk/integration/page/LoginPage.kt
@@ -61,10 +61,16 @@ class LoginPage : BasePage() {
         }
 
         device.waitForIdle()
-        waitByResource("emailInput")
+        waitByResource("root")
+
+        val loginTab = device.findObject(selector.className("android.view.View").textMatches("(Login|Anmelden)"))
+        if (loginTab.exists()) {
+            loginTab.click()
+            device.waitForIdle()
+        }
 
         // accept cookies
-        val acceptCookies = device.findObject(selector.className("android.widget.Button").textMatches("(Akzeptieren|Accept)"))
+        val acceptCookies = device.findObject(selector.className("android.widget.Button").textMatches("(Accept|Akzeptieren)"))
         if (acceptCookies.exists()) {
             acceptCookies.click()
             device.waitForIdle()


### PR DESCRIPTION
[SDK-248](https://gesundheitscloud.atlassian.net/browse/SDK-248)
Authorization was not passing on dev environment in integration tests because web page when rendered have left create account tab in focus instead of login tab.