### PR TITLE
Add CI job for daily login verification

### DIFF
--- a/.github/workflows/d4l-ci-android-login-verification.yml
+++ b/.github/workflows/d4l-ci-android-login-verification.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 7 * * *'
 
 jobs:
-  build-and-verify:
+  verify-login:
 
     runs-on: [self-hosted, macos]
 


### PR DESCRIPTION
To have a better view on changes done for the AuthApp we establish ab daily test run against all environment to monitor breaking changes and create awareness.