### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -63,6 +63,7 @@ toc::[]
 * ThreeTenABP 1.3.0 -> 1.4.0
 * AndroidX TestCore 1.3.0 -> 1.4.0
 * AndroidX Test 1.3.0 -> 1.4.0
+* AndroidX Test Orchestrator 1.4.0 -> 1.4.1
 * AndroidX Espresso 3.3.0 -> 3.4.0
 * AndroidX Test ExtJunit 1.1.2 -> 1.1.3
 * OkHttp 4.8.1 -> 4.9.1

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -45,10 +45,11 @@ toc::[]
 === Bumped
 
 * Gradle 6.9.1 -> 7.4.2
-* HC SDK KMP 1.9.2 -> 1.15.1
-* HC FHIR SDK Java 1.2.1 -> 1.6.3
-* HC FHIR Helper 1.4.1 -> 1.7.1
-* HC Util SDK 1.4.1 -> 1.10.0
+* HC SDK KMP 1.9.2 -> 1.16.0
+* HC FHIR SDK Java 1.2.1 -> 1.8.0
+* HC FHIR Helper 1.4.1 -> 1.9.0
+* HC Auth SDK 1.14.0 -> 1.15.0
+* HC Util SDK 1.4.1 -> 1.13.0
 * Kotlin 1.4.31 -> 1.4.32
 * Kotlin Coroutines 1.4.2 -> 1.4.3
 * Android Gradle Plugin 4.1.2 -> 7.2.0

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -66,7 +66,7 @@ toc::[]
 * AndroidX Test Orchestrator 1.4.0 -> 1.4.1
 * AndroidX Espresso 3.3.0 -> 3.4.0
 * AndroidX Test ExtJunit 1.1.2 -> 1.1.3
-* OkHttp 4.8.1 -> 4.9.1
+* OkHttp 4.8.1 -> 4.9.3
 * Gson 2.8.6 -> 2.8.7
 * Dependency Updates Gradle plugin 0.38.0 -> 0.39.0
 * Gradle Download plugin 4.1.1 -> 4.1.2
@@ -74,5 +74,6 @@ toc::[]
 * KtLint 0.41.0 -> 0.45.2
 * Kotlin 1.4.32 -> 1.6.20
 * Kotlin Coroutines 1.4.3 -> 1.6.1
+* AppAuth 0.10.0 -> 0.11.1
 
 === Migration

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -68,7 +68,7 @@ toc::[]
 * AndroidX Espresso 3.3.0 -> 3.4.0
 * AndroidX Test ExtJunit 1.1.2 -> 1.1.3
 * OkHttp 4.8.1 -> 4.9.3
-* Gson 2.8.6 -> 2.8.7
+* Gson 2.8.6 -> 2.8.9
 * Dependency Updates Gradle plugin 0.38.0 -> 0.39.0
 * Gradle Download plugin 4.1.1 -> 4.1.2
 * Spotless 5.10.2 -> 6.5.1

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -51,7 +51,7 @@ toc::[]
 * HC Util SDK 1.4.1 -> 1.10.0
 * Kotlin 1.4.31 -> 1.4.32
 * Kotlin Coroutines 1.4.2 -> 1.4.3
-* Android Gradle Plugin 4.1.2 -> 7.1.3
+* Android Gradle Plugin 4.1.2 -> 7.2.0
 * Android Desugar 1.0.5 -> 1.1.5
 * AndroidX Ktx 1.3.1 -> 1.7.0
 * AndroidX AppCompat 1.2.0 -> 1.4.1

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -71,7 +71,7 @@ toc::[]
 * Gson 2.8.6 -> 2.8.7
 * Dependency Updates Gradle plugin 0.38.0 -> 0.39.0
 * Gradle Download plugin 4.1.1 -> 4.1.2
-* Spotless 5.10.2 -> 6.4.2
+* Spotless 5.10.2 -> 6.5.1
 * KtLint 0.41.0 -> 0.45.1
 * Kotlin 1.4.32 -> 1.6.10
 * Kotlin Coroutines 1.4.3 -> 1.6.1

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -72,7 +72,7 @@ toc::[]
 * Gradle Download plugin 4.1.1 -> 4.1.2
 * Spotless 5.10.2 -> 6.4.2
 * KtLint 0.41.0 -> 0.45.2
-* Kotlin 1.4.32 -> 1.6.20
+* Kotlin 1.4.32 -> 1.6.10
 * Kotlin Coroutines 1.4.3 -> 1.6.1
 * AppAuth 0.10.0 -> 0.11.1
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -72,7 +72,7 @@ toc::[]
 * Dependency Updates Gradle plugin 0.38.0 -> 0.39.0
 * Gradle Download plugin 4.1.1 -> 4.1.2
 * Spotless 5.10.2 -> 6.4.2
-* KtLint 0.41.0 -> 0.45.2
+* KtLint 0.41.0 -> 0.45.1
 * Kotlin 1.4.32 -> 1.6.10
 * Kotlin Coroutines 1.4.3 -> 1.6.1
 * AppAuth 0.10.0 -> 0.11.1

--- a/app-android/src/androidTest/java/care/data4life/integration/app/crud/BaseTest.kt
+++ b/app-android/src/androidTest/java/care/data4life/integration/app/crud/BaseTest.kt
@@ -13,6 +13,7 @@ import care.data4life.integration.app.testUtils.NetworkUtil
 import care.data4life.integration.app.testUtils.TestConfigLoader
 import care.data4life.integration.app.testUtils.deleteAllRecords
 import care.data4life.sdk.Data4LifeClient
+import care.data4life.sdk.SdkContract
 import care.data4life.sdk.lang.D4LException
 import care.data4life.sdk.listener.Callback
 import care.data4life.sdk.listener.ResultListener
@@ -22,7 +23,7 @@ import org.junit.*
 import org.junit.Assert.*
 import org.junit.Assume.assumeTrue
 import org.junit.runners.MethodSorters
-import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertNotEquals
@@ -315,7 +316,11 @@ abstract class BaseTest<T : DomainResource> {
         client.fetchRecords(
             getTestClass(),
             null,
-            LocalDate.now(),
+            SdkContract.UpdateDateTimeRange(
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now()
+            ),
+            false,
             1000,
             0,
             object : TestResultListener<List<Record<T>>>() {

--- a/app-android/src/androidTest/java/care/data4life/integration/app/testUtils/SDKHelpers.kt
+++ b/app-android/src/androidTest/java/care/data4life/integration/app/testUtils/SDKHelpers.kt
@@ -6,12 +6,14 @@ package care.data4life.integration.app.testUtils
 
 import care.data4life.fhir.stu3.model.DomainResource
 import care.data4life.sdk.Data4LifeClient
+import care.data4life.sdk.SdkContract
 import care.data4life.sdk.lang.D4LException
 import care.data4life.sdk.listener.ResultListener
 import care.data4life.sdk.model.DeleteResult
 import care.data4life.sdk.model.Record
 import kotlinx.coroutines.runBlocking
 import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -26,8 +28,15 @@ fun <T : DomainResource> Data4LifeClient.deleteAllRecords(clazz: Class<T>) {
 private suspend fun <T : DomainResource> fetchRecords(clazz: Class<T>): List<Record<T>> = suspendCoroutine { cont ->
     Data4LifeClient.getInstance().fetchRecords(
         clazz,
-        LocalDate.now().minusYears(10),
-        LocalDate.now(),
+        SdkContract.CreationDateRange(
+            LocalDate.now().minusYears(5),
+            LocalDate.now()
+        ),
+        SdkContract.UpdateDateTimeRange(
+            LocalDateTime.now().minusDays(10),
+            LocalDateTime.now()
+        ),
+        false,
         1000,
         0,
         object : ResultListener<List<Record<T>>> {

--- a/app-android/src/androidTest/java/care/data4life/integration/app/testUtils/TestConfig.kt
+++ b/app-android/src/androidTest/java/care/data4life/integration/app/testUtils/TestConfig.kt
@@ -39,7 +39,7 @@ object TestConfigLoader {
 
             return Gson().fromJson(json, TestConfig::class.java)
         } catch (error: FileNotFoundException) {
-            throw IllegalStateException("Please run './gradlew provideAndroidTestConfig' before running the tests", error)
+            throw IllegalStateException("Please run './gradlew provideTestConfig' before running the tests", error)
         }
     }
 }

--- a/app-android/src/main/java/care/data4life/integration/app/ui/home/HomeFragment.kt
+++ b/app-android/src/main/java/care/data4life/integration/app/ui/home/HomeFragment.kt
@@ -15,6 +15,7 @@ import androidx.navigation.fragment.NavHostFragment.Companion.findNavController
 import care.data4life.integration.app.MainViewModel
 import care.data4life.integration.app.R
 import care.data4life.integration.app.databinding.HomeFragmentBinding
+import care.data4life.sdk.SdkContract
 import care.data4life.sdk.call.Fhir4Record
 import care.data4life.sdk.fhir.Fhir3Resource
 import care.data4life.sdk.fhir.Fhir4Resource
@@ -23,6 +24,7 @@ import care.data4life.sdk.listener.Callback
 import care.data4life.sdk.listener.ResultListener
 import care.data4life.sdk.model.Record
 import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
 
 class HomeFragment : Fragment() {
 
@@ -50,8 +52,15 @@ class HomeFragment : Fragment() {
         binding.homeFhir3LoadAllButton.setOnClickListener {
             model.client.fetchRecords(
                 Fhir3Resource::class.java,
-                LocalDate.now().minusYears(1),
-                LocalDate.now(),
+                SdkContract.CreationDateRange(
+                    LocalDate.now().minusYears(2),
+                    LocalDate.now().minusYears(1)
+                ),
+                SdkContract.UpdateDateTimeRange(
+                    LocalDateTime.now().minusDays(2),
+                    LocalDateTime.now()
+                ),
+                false,
                 50,
                 0,
                 object : ResultListener<List<Record<Fhir3Resource>>> {
@@ -72,8 +81,15 @@ class HomeFragment : Fragment() {
             model.client.fhir4.search(
                 Fhir4Resource::class.java,
                 emptyList(),
-                LocalDate.now().minusYears(1),
-                LocalDate.now(),
+                SdkContract.CreationDateRange(
+                    LocalDate.now().minusYears(2),
+                    LocalDate.now().minusYears(1)
+                ),
+                SdkContract.UpdateDateTimeRange(
+                    LocalDateTime.now().minusDays(2),
+                    LocalDateTime.now()
+                ),
+                false,
                 50,
                 0,
                 object : care.data4life.sdk.call.Callback<List<Fhir4Record<Fhir4Resource>>> {

--- a/app-java/build.gradle
+++ b/app-java/build.gradle
@@ -33,6 +33,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
-    implementation("care.data4life.hc-sdk-kmp:sdk-jvm:1.15.1")
+    implementation("care.data4life.hc-sdk-kmp:sdk-jvm:1.16.0")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ allprojects {
             credentials.password = project.findProperty("gpr.key") as String? ?: System.getenv("PACKAGE_REGISTRY_DOWNLOAD_TOKEN")
         }
 
-//        d4l()
+        d4l()
     }
 
     // FIXME remove if dependency conflict is solved

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     // download scripts
     implementation("de.undercouch:gradle-download-task:4.1.2")
     // quality.gradle.kts
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.4.2")
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.5.1")
     implementation("com.pinterest:ktlint:0.45.1")
     // versioning.gradle.kts
     implementation("com.palantir.gradle.gitversion:gradle-git-version:0.12.3")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.code.gson:gson:2.8.7")
+    implementation("com.google.code.gson:gson:2.8.9")
 
     // dependency check
     implementation("com.github.ben-manes:gradle-versions-plugin:0.39.0")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation("de.undercouch:gradle-download-task:4.1.2")
     // quality.gradle.kts
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.4.2")
-    implementation("com.pinterest:ktlint:0.45.2")
+    implementation("com.pinterest:ktlint:0.45.1")
     // versioning.gradle.kts
     implementation("com.palantir.gradle.gitversion:gradle-git-version:0.12.3")
 }

--- a/buildSrc/src/main/kotlin/D4LConfigHelper.kt
+++ b/buildSrc/src/main/kotlin/D4LConfigHelper.kt
@@ -1,41 +1,9 @@
 /*
- * Copyright (c) 2020 D4L data4life gGmbH - All rights reserved.
+ * Copyright (c) 2022 D4L data4life gGmbH - All rights reserved.
  */
 
 import com.google.gson.GsonBuilder
 import java.io.File
-
-/*
- * BSD 3-Clause License
- *
- * Copyright (c) 2020, HPS Gesundheitscloud gGmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
- *
- *  Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- *  Neither the name of the copyright holder nor the names of its
- * contributors may be used to endorse or promote products derived from
- * this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 
 object D4LConfigHelper {
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -62,7 +62,7 @@ object Dependencies {
             const val androidXTestCore = "androidx.test:core:${Versions.androidXTestCore}"
             const val androidXTestRunner = "androidx.test:runner:${Versions.androidXTest}"
             const val androidXTestRules = "androidx.test:rules:${Versions.androidXTest}"
-            const val androidXTestOrchestrator = "androidx.test:orchestrator:${Versions.androidXTest}"
+            const val androidXTestOrchestrator = "androidx.test:orchestrator:${Versions.androidXTestOrchestrator}"
 
             const val androidXTestExtJUnit = "androidx.test.ext:junit:${Versions.androidXTestExtJUnit}"
 

--- a/buildSrc/src/main/kotlin/GradlePlugins.kt
+++ b/buildSrc/src/main/kotlin/GradlePlugins.kt
@@ -1,40 +1,5 @@
 /*
- * Copyright (c) 2020 D4L data4life gGmbH - All rights reserved.
- */
-
-import org.gradle.plugin.use.PluginDependenciesSpec
-import org.gradle.plugin.use.PluginDependencySpec
-
-/*
- * BSD 3-Clause License
- *
- * Copyright (c) 2020, HPS Gesundheitscloud gGmbH
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *  Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
- *
- *  Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- *  Neither the name of the copyright holder nor the names of its
- * contributors may be used to endorse or promote products derived from
- * this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) 2022 D4L data4life gGmbH - All rights reserved.
  */
 
 object GradlePlugins {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -56,13 +56,13 @@ object Versions {
     const val material = "1.5.0"
 
     // Auth
-    const val appAuth = "0.10.0"
+    const val appAuth = "0.11.1"
 
     // Network
     /**
      * [okHttp](https://github.com/square/okhttp)
      */
-    const val okHttp = "4.9.1"
+    const val okHttp = "4.9.3"
 
     /**
      *

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -7,24 +7,24 @@ object Versions {
     /**
      * [D4L-SDK](https://github.com/d4l-data4life/hc-sdk-kmp)
      */
-    const val hcSdk = "1.15.1"
+    const val hcSdk = "1.16.0"
 
     /**
      * [D4L-FHIR-SDK-JAVA](https://github.com/d4l-data4life/hc-fhir-sdk-java)
      */
-    const val fhirSdk = "1.6.3"
+    const val fhirSdk = "1.8.0"
 
     /**
      * [D4L-FHIR-HELPER-SDK-KMP](https://github.com/d4l-data4life/hc-fhir-helper-sdk-kmp)
      */
-    const val fhirHelper = "1.7.1"
+    const val fhirHelper = "1.9.0"
 
     /**
      * [D4L-UTIL-SDK-KMP](https://github.com/d4l-data4life/hc-util-sdk-kmp)
      */
-    const val utilSdk = "1.10.0"
+    const val utilSdk = "1.13.0"
 
-    const val authSdk = "1.14.0"
+    const val authSdk = "1.15.0"
 
     const val kotlin = "1.6.10"
     const val kotlinCoroutines = "1.6.1"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -31,7 +31,7 @@ object Versions {
 
     object GradlePlugins {
         const val kotlin = Versions.kotlin
-        const val android = "7.1.3"
+        const val android = "7.2.0"
 
         /**
          * [Dexcount](https://github.com/KeepSafe/dexcount-gradle-plugin)

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -26,7 +26,7 @@ object Versions {
 
     const val authSdk = "1.14.0"
 
-    const val kotlin = "1.6.20"
+    const val kotlin = "1.6.10"
     const val kotlinCoroutines = "1.6.1"
 
     object GradlePlugins {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -87,6 +87,7 @@ object Versions {
     // Android Test
     const val androidXTestCore = "1.4.0"
     const val androidXTest = "1.4.0"
+    const val androidXTestOrchestrator = "1.4.1"
     const val androidXEspresso = "3.4.0"
     const val androidXUiAutomator = "2.2.0"
     const val androidXTestExtJUnit = "1.1.3"

--- a/buildSrc/src/main/kotlin/scripts/quality-spotless.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/quality-spotless.gradle.kts
@@ -19,7 +19,7 @@ package scripts
 /**
  * You need to add following dependencies to the buildSrc/build.gradle.kts
  *
- * - implementation("com.diffplug.spotless:spotless-plugin-gradle:5.4.2")
+ * - implementation("com.diffplug.spotless:spotless-plugin-gradle:6.5.1")
  * - implementation("com.pinterest:ktlint:0.45.1")
  *
  */

--- a/buildSrc/src/main/kotlin/scripts/quality-spotless.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/quality-spotless.gradle.kts
@@ -20,14 +20,14 @@ package scripts
  * You need to add following dependencies to the buildSrc/build.gradle.kts
  *
  * - implementation("com.diffplug.spotless:spotless-plugin-gradle:5.4.2")
- * - implementation("com.pinterest:ktlint:0.45.2")
+ * - implementation("com.pinterest:ktlint:0.45.1")
  *
  */
 plugins {
     id("com.diffplug.spotless")
 }
 
-val ktlintVersion = "0.45.2"
+val ktlintVersion = "0.45.1"
 
 spotless {
     kotlin {


### PR DESCRIPTION
### :tophat: What is the goal?

Update integration project to latest SDK version.

### :unicorn: How is it being implemented?

#### Bumped

* HC SDK KMP 1.15.1 -> 1.6.0
* HC FHIR SDK Java 1.6.3 -> 1.8.0
* HC FHIR Helper 1.7.1 -> 1.9.0
* HC Util SDK 1.10.0 -> 1.13.0

* Android Gradle Plugin 7.1.3 -> 7.2.0
* AndroidX Test Orchestrator 1.4.0 -> 1.4.1

* OkHttp 4.9.1 -> 4.9.3
* Gson 2.8.7 -> 2.8.9

* AppAuth 0.10.0 -> 0.11.1

* Spotless 6.4.2 -> 6.5.1

##### Downgrade

To be compatible with Jetpack Compose Kotlin had to be downgraded

* KtLint 0.45.2 -> 0.45.1
* Kotlin 1.6.20 -> 1.6.10

### :thinking: DOD Checklist

- [x] My code follows the code style and naming conventions of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
- [x] I have updated the changelog accordingly.
